### PR TITLE
feat(templates): add Home Assistant compose template

### DIFF
--- a/config/constants.php
+++ b/config/constants.php
@@ -4,7 +4,7 @@ return [
     'coolify' => [
         'version' => '4.0.0-beta.427',
         'helper_version' => '1.0.10',
-        'realtime_version' => '1.0.10',
+        'realtime_version' => '1.0.11',
         'self_hosted' => env('SELF_HOSTED', true),
         'autoupdate' => env('AUTOUPDATE'),
         'base_config_path' => env('BASE_CONFIG_PATH', '/data/coolify'),

--- a/docker/coolify-realtime/package-lock.json
+++ b/docker/coolify-realtime/package-lock.json
@@ -7,7 +7,7 @@
             "dependencies": {
                 "@xterm/addon-fit": "0.10.0",
                 "@xterm/xterm": "5.5.0",
-                "axios": "1.8.4",
+                "axios": "1.12.0",
                 "cookie": "1.0.2",
                 "dotenv": "16.5.0",
                 "node-pty": "1.0.0",
@@ -36,13 +36,13 @@
             "license": "MIT"
         },
         "node_modules/axios": {
-            "version": "1.8.4",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.4.tgz",
-            "integrity": "sha512-eBSYY4Y68NNlHbHBMdeDmKNtDgXWhQsJcGqzO3iLUM0GraQFSS9cVgPX5I9b3lbdFKyYoAEGAZF1DwhTaljNAw==",
+            "version": "1.12.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.0.tgz",
+            "integrity": "sha512-oXTDccv8PcfjZmPGlWsPSwtOJCZ/b6W5jAMCNcfwJbCzDckwG0jrYJFaWH1yvivfCXjVzV/SPDEhMB3Q+DSurg==",
             "license": "MIT",
             "dependencies": {
                 "follow-redirects": "^1.15.6",
-                "form-data": "^4.0.0",
+                "form-data": "^4.0.4",
                 "proxy-from-env": "^1.1.0"
             }
         },

--- a/docker/coolify-realtime/package.json
+++ b/docker/coolify-realtime/package.json
@@ -5,7 +5,7 @@
         "@xterm/addon-fit": "0.10.0",
         "@xterm/xterm": "5.5.0",
         "cookie": "1.0.2",
-        "axios": "1.8.4",
+        "axios": "1.12.0",
         "dotenv": "16.5.0",
         "node-pty": "1.0.0",
         "ws": "8.18.1"


### PR DESCRIPTION
This pull request adds a new Docker Compose template for Home Assistant, providing a ready-to-use configuration for deploying the open-source home automation platform.

New Home Assistant Compose template:

    Added templates/compose/home-assistant.yaml with a complete Docker Compose configuration for Home Assistant, including service definition, environment variables, port mappings, volume for persistent data, healthcheck, and restart policy.
    Included metadata at the top of the file such as documentation link, slogan, category, tags, logo reference, and default port to improve discoverability and usability.

